### PR TITLE
[FIX] fixes #184

### DIFF
--- a/sirbot-pyslackers/endpoints/slack/messages.py
+++ b/sirbot-pyslackers/endpoints/slack/messages.py
@@ -54,6 +54,8 @@ async def stock_quote(message, app):
             LOG.error("Error retrieving stock quotes: %s", e)
             response["text"] = "Unable to retrieve quotes right now."
     else:
+        # Sometimes the API returns None records. We remove them here.
+        quote = {k: v for k, v in quote.items() if v is not None}
         change = quote.get("change", 0)
         color = "gray"
         if change > 0:


### PR DESCRIPTION
The stocks API sometimes returns records with None values, so I filter them out with a list comp. Then, the `get` methods will default to certain values if the record was dropped.

Tested this on my dev slack team.
![screenshot from 2018-10-24 12-52-17](https://user-images.githubusercontent.com/23350919/47447955-c4167700-d78c-11e8-94bd-f7e51344d443.png)
