### PR TITLE
[FEATURE] Add crypto API support to stocks plugin.

### DIFF
--- a/sirbot-pyslackers/endpoints/slack/messages.py
+++ b/sirbot-pyslackers/endpoints/slack/messages.py
@@ -57,7 +57,7 @@ async def crypto_quote(message, app):
         LOG.debug("Crypto quote from IEX API: %s", quote)
     except ClientResponseError as e:
         LOG.error("Error retrieving crypto quotes: %s", e)
-    else:
+    if quote is not None:
         # Sometimes the API returns None records. We remove them here.
         quote = {k: v for k, v in quote.items() if v is not None}
         change = quote.get("change", 0)

--- a/sirbot-pyslackers/endpoints/slack/messages.py
+++ b/sirbot-pyslackers/endpoints/slack/messages.py
@@ -53,7 +53,7 @@ async def crypto_quote(message, app):
                 break
         if quote is None:
             response["text"] = f"The crypto symbol `{symbol}` could not be found"
-            LOG.error("No crypto currencies found when searching for: %s", symbol)
+            LOG.debug("No crypto currencies found when searching for: %s", symbol)
         LOG.debug("Crypto quote from IEX API: %s", quote)
     except ClientResponseError as e:
         LOG.error("Error retrieving crypto quotes: %s", e)

--- a/sirbot-pyslackers/endpoints/slack/messages.py
+++ b/sirbot-pyslackers/endpoints/slack/messages.py
@@ -69,7 +69,6 @@ async def crypto_quote(message, app):
             attachments=[
                 {
                     "color": color,
-                    "thumb_url": logo,
                     "title": f'{quote["symbol"]} ({quote["companyName"]}): '
                     f'${quote["latestPrice"]:,.4f}',
                     "title_link": f"https://finance.yahoo.com/quote/{symbol}",

--- a/sirbot-pyslackers/endpoints/slack/messages.py
+++ b/sirbot-pyslackers/endpoints/slack/messages.py
@@ -51,7 +51,7 @@ async def crypto_quote(message, app):
             if c["symbol"] == f"{symbol}USDT":
                 quote = c
                 break
-        if quote == None:
+        if quote is None:
             response["text"] = f"The crypto symbol `{symbol}` could not be found"
             LOG.error("No crypto currencies found when searching for: %s", symbol)
         LOG.debug("Crypto quote from IEX API: %s", quote)

--- a/sirbot-pyslackers/endpoints/slack/messages.py
+++ b/sirbot-pyslackers/endpoints/slack/messages.py
@@ -31,6 +31,87 @@ def create_endpoints(plugin):
     # stock tickers are 1-5 capital characters, with a dot allowed. To keep
     # this from triggering with random text we require a leading '$'
     plugin.on_message("s\$[A-Z\.]{1,5}", stock_quote, wait=False)
+    plugin.on_message("c\$[A-Z\.]{1,5}", crypto_quote, wait=False)
+
+async def crypto_quote(message, app):
+    match = STOCK_REGEX.search(message.get("text", ""))
+    if not match:
+        return
+
+    symbol = match.group("symbol")
+    LOG.debug("Fetching crypto quotes for symbol %s", symbol)
+
+    response = message.response()
+    try:
+        stocks = app["plugins"]["stocks"]
+        crypto = (await stocks.crypto())
+        quote = ''
+        for c in crypto:
+            if c["symbol"] == f"{symbol}USDT":
+                quote = c
+        if quote == '':
+            raise Exception
+        LOG.debug("Crypto quote from IEX API: %s", quote)
+    except Exception as e:
+        response["text"] = f"The crypto symbol `{symbol}` could not be found"
+        LOG.error("Error retrieving crypto quotes: %s", e)
+    else:
+        # Sometimes the API returns None records. We remove them here.
+        quote = {k: v for k, v in quote.items() if v is not None}
+        change = quote.get("change", 0)
+        color = "gray"
+        if change > 0:
+            color = "good"
+        elif change < 0:
+            color = "danger"
+
+        response.update(
+            attachments=[
+                {
+                    "color": color,
+                    "thumb_url": logo,
+                    "title": f'{quote["symbol"]} ({quote["companyName"]}): '
+                    f'${quote["latestPrice"]:,.4f}',
+                    "title_link": f"https://finance.yahoo.com/quote/{symbol}",
+                    "fields": [
+                        {
+                            "title": "Change",
+                            "value": f'${quote.get("change", 0):,.4f} ({quote.get("changePercent", 0) * 100:,.4f}%)',
+                            "short": True,
+                        },
+                        {
+                            "title": "Volume",
+                            "value": f'{quote["latestVolume"]:,}',
+                            "short": True,
+                        },
+                        {
+                            "title": "Low",
+                            "value": f'${quote["low"]:,.4f}',
+                            "short": True,
+                        },
+                        {
+                            "title": "High",
+                            "value": f'${quote["high"]:,.4f}',
+                            "short": True,
+                        },
+                        {
+                            "title": "Latest time of quote",
+                            "value": f'{quote["latestTime"]} EST',
+                            "short": True,
+                        },
+                    ],
+                    "footer": f"Data provided for free by "
+                    f"<https://iextrading.com/developer|IEX>. View "
+                    f"<https://iextrading.com/api-exhibit-a/|"
+                    f"IEX's Terms of Use>.",
+                    "footer_icon": "https://iextrading.com/apple-touch-icon.png",  # noqa
+                    "ts": quote.get("latestUpdate", 0) / 1000,
+                }
+            ]
+        )
+    await app["plugins"]["slack"].api.query(
+        url=methods.CHAT_POST_MESSAGE, data=response
+    )
 
 
 async def stock_quote(message, app):

--- a/sirbot-pyslackers/plugins/stocks.py
+++ b/sirbot-pyslackers/plugins/stocks.py
@@ -22,3 +22,10 @@ class StocksPlugin:
         async with self.session.get(url) as r:
             r.raise_for_status()
             return await r.json()
+
+    async def crypto(self):
+        """https://iextrading.com/developer/docs/#crypto"""
+        url = self.API_ROOT + f"/stock/market/crypto"
+        async with self.session.get(url) as r:
+            r.raise_for_status()
+            return await r.json()

--- a/sirbot-pyslackers/plugins/stocks.py
+++ b/sirbot-pyslackers/plugins/stocks.py
@@ -25,7 +25,7 @@ class StocksPlugin:
 
     async def crypto(self):
         """https://iextrading.com/developer/docs/#crypto"""
-        url = self.API_ROOT + f"/stock/market/crypto"
+        url = self.API_ROOT + "/stock/market/crypto"
         async with self.session.get(url) as r:
             r.raise_for_status()
             return await r.json()


### PR DESCRIPTION
The IEX API used for querying stock quotes now has support for crypto currencies. In this PR I extended the stocks plugin to use the new endpoint, and differentiate between a stock request with the leading characters being a `c$<symbol>` instead of `s$<symbol>`.

This is how it looks in my dev environment:
![screenshot from 2018-10-29 23-52-14](https://user-images.githubusercontent.com/23350919/47694892-ff260980-dbd5-11e8-9117-d44cd1cf565c.png)

This is what it looks like if a symbol could not be found:
![screenshot from 2018-10-29 23-54-57](https://user-images.githubusercontent.com/23350919/47694915-1107ac80-dbd6-11e8-821e-b0ab993c595d.png)

