### PR TITLE
Fixes #194

### DIFF
--- a/sirbot-pyslackers/endpoints/slack/messages.py
+++ b/sirbot-pyslackers/endpoints/slack/messages.py
@@ -87,7 +87,7 @@ async def crypto_quote(message, app):
                         },
                         {
                             "title": "Low",
-                            "value": f'${quote.get("low"]:,.4f}',
+                            "value": f'${quote.get("low", 0):,.4f}',
                             "short": True,
                         },
                         {

--- a/sirbot-pyslackers/endpoints/slack/messages.py
+++ b/sirbot-pyslackers/endpoints/slack/messages.py
@@ -82,22 +82,22 @@ async def crypto_quote(message, app):
                         },
                         {
                             "title": "Volume",
-                            "value": f'{quote["latestVolume"]:,}',
+                            "value": f'{quote.get("latestVolume", 0):,}',
                             "short": True,
                         },
                         {
                             "title": "Low",
-                            "value": f'${quote["low"]:,.4f}',
+                            "value": f'${quote.get("low"]:,.4f}',
                             "short": True,
                         },
                         {
                             "title": "High",
-                            "value": f'${quote["high"]:,.4f}',
+                            "value": f'${quote.get("high", 0):,.4f}',
                             "short": True,
                         },
                         {
                             "title": "Latest time of quote",
-                            "value": f'{quote["latestTime"]} EST',
+                            "value": f'{quote.get("latestTime", "N/A")} EST',
                             "short": True,
                         },
                     ],
@@ -161,12 +161,12 @@ async def stock_quote(message, app):
                         },
                         {
                             "title": "Volume",
-                            "value": f'{quote["latestVolume"]:,}',
+                            "value": f'{quote.get("latestVolume", 0):,}',
                             "short": True,
                         },
                         {
                             "title": "Open",
-                            "value": f'${quote["open"]:,.4f}',
+                            "value": f'${quote.get("open", 0):,.4f}',
                             "short": True,
                         },
                         {
@@ -176,12 +176,12 @@ async def stock_quote(message, app):
                         },
                         {
                             "title": "Low",
-                            "value": f'${quote["low"]:,.4f}',
+                            "value": f'${quote.get("low", 0):,.4f}',
                             "short": True,
                         },
                         {
                             "title": "High",
-                            "value": f'${quote["high"]:,.4f}',
+                            "value": f'${quote("high", 0):,.4f}',
                             "short": True,
                         },
                     ],


### PR DESCRIPTION
Unfortunately we are unable to determine what fields may or may not be null with the IEX API so I have used `get` methods to avoid throwing a `KeyError` if or when something is missing. I did not use the `get` method for the `title` string in the response attachment because a missing symbol would throw an exception in the `try` block where the API is queried.